### PR TITLE
[UI-712] include query in netlify cache key

### DIFF
--- a/pages/api/og.tsx
+++ b/pages/api/og.tsx
@@ -182,6 +182,9 @@ export default function (req: NextRequest) {
       {
         width: 1200,
         height: 630,
+        headers: {
+          'netlify-vary': 'query'
+        }
       }
     );
   } catch (e: any) {


### PR DESCRIPTION
Trying the netlify-very response header to tell netlify to include the query string in the cache key